### PR TITLE
Display date conforming to ISO 8601

### DIFF
--- a/views/answer/view.php
+++ b/views/answer/view.php
@@ -19,7 +19,7 @@ $this->title = $model->question->text.' '.Yii::t('app', 'Brain Calibrator');
         <p class="<?=$model->isCorrect?'text-success':'text-danger'?>" ><strong><?=Yii::t('app', '90%')?>:</strong> <?=Yii::t('app', 'From <strong>{0}</strong> to <strong>{1}</strong>', [number_format($model->ninetyStart,0,'.',' '), number_format($model->ninetyEnd,0,'.',' ')])?></p>
         <p class="<?=$model->isCorrect>1?'text-success':'text-danger'?>" ><strong><?=Yii::t('app', '50%')?>:</strong> <?=Yii::t('app', 'From <strong>{0}</strong> to <strong>{1}</strong>', [number_format($model->fiftyStart,0,'.',' '), number_format($model->fiftyEnd,0,'.',' ')])?></p>
         <h2><?=Yii::t('app', 'Your score')?>: <label class="label <?=$model->score > 50 ? 'label-success' : 'label-warning'?>"><?=$model->score?></label></h2>
-        <p class="help-block"><?=Yii::t('app', 'You are answered this question')?> <?=date('d-m-Y',$model->dateSubmitted)?></p>
+        <p class="help-block"><?=Yii::t('app', 'You are answered this question')?> <?=date('Y-m-d',$model->dateSubmitted)?></p>
         <p>
             <?=Html::a(Yii::t('app', 'Next question'), ['site/index'], ['class' => 'btn btn-lg btn-primary'])?>
         </p>


### PR DESCRIPTION
Формат даты "день-месяц-год" категорически неверен, не соответствует никакому общепринятому способу написания дат. Универсальнее всего использовать ISO 8601, а совсем в идеале форматировать согласно локали пользователя.

Ну [серьёзно](https://xkcd.ru/1179/)
![ISO 8601](https://xkcd.ru/i/1179_v2.png)